### PR TITLE
Render logs from match object

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -31,16 +31,4 @@ int game_new(struct game *game, const char *match_script);
  */
 void game_draw(struct game *game);
 
-#define game_log(game, fmt, ...) game_log_styled(game, TB_DEFAULT, TB_DEFAULT, fmt,##__VA_ARGS__)
-
-/*
- * Add a log line to the game.
- * @param game The game structure to log to.
- * @param fg The foreground color of the text.
- * @param bg The background color of the text.
- * @param fmt The format string for the log line.
- * @param ... The format string arguments.
- */
-void game_log_styled(struct game *game, int fg, int bg, const char *fmt, ...);
-
 #endif

--- a/include/ui/screen.h
+++ b/include/ui/screen.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <termbox.h>
+#include <lua.h>
 
 #define LOG_LINE_COUNT 3
 
@@ -29,5 +30,6 @@ struct screen {
 void screen_init(struct screen *screen);
 void screen_draw_window(const struct screen *screen, const struct tb_cell *window);
 void screen_draw_object(const struct screen *screen, struct tb_cell object, size_t x, size_t y);
+void screen_draw_logs(const struct screen *screen, lua_State *env);
 
 #endif

--- a/include/ui/screen.h
+++ b/include/ui/screen.h
@@ -15,16 +15,8 @@
 
 #define OBJECT_COUNT 54 * 14
 
-struct log_node {
-    int fg;
-    int bg;
-    char *content;
-    struct log_node *next;
-};
-
 struct screen {
     struct tb_cell info[INFO_WIDTH * INFO_HEIGHT];
-    struct log_node *log;
 };
 
 void screen_init(struct screen *screen);

--- a/include/util.h
+++ b/include/util.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <termbox.h>
+#include <stdio.h>
 
 #define verify(pred, fmt, ...) do { \
     if (!(pred)) { \

--- a/src/game.c
+++ b/src/game.c
@@ -35,16 +35,12 @@ int game_new(struct game *game, const char *match_script) {
     verify(game->screen != NULL, "could not allocate screen");
     screen_init(game->screen);
 
-    game_log(game, "Welcome to etac v0.0.1");
-
     lua_pushstring(game->env, "title");
     lua_gettable(game->env, -2);
-    game_log(game, "loaded match: %s", lua_tostring(game->env, -1));
     lua_pop(game->env, 1);
 
     lua_pushstring(game->env, "description");
     lua_gettable(game->env, -2);
-    game_log(game, "%s", lua_tostring(game->env, -1));
     lua_pop(game->env, 1);
 
     return 0;
@@ -136,35 +132,4 @@ void game_draw(struct game *game) {
     }
 
     tb_present();
-}
-
-void game_log_styled(struct game *game, int fg, int bg, const char *fmt, ...) {
-    va_list args;
-    int length = 0;
-    struct log_node *log_entry = malloc(sizeof *log_entry);
-
-    if (log_entry == NULL) {
-        fprintf(stderr, "error: could not allocate log entry\n");
-        exit(EXIT_FAILURE);
-    }
-
-    va_start(args, fmt);
-    length = vsnprintf(log_entry->content, 0, fmt, args);
-    va_end(args);
-
-    log_entry->content = malloc(length + 1);
-    if (log_entry->content == NULL) {
-        fprintf(stderr, "error: could not allocate log entry content\n");
-        exit(EXIT_FAILURE);
-    }
-
-    va_start(args, fmt);
-    vsnprintf(log_entry->content, length + 1, fmt, args);
-    va_end(args);
-
-    log_entry->fg = fg;
-    log_entry->bg = bg;
-    log_entry->next = game->screen->log;
-
-    game->screen->log = log_entry;
 }

--- a/src/game.c
+++ b/src/game.c
@@ -96,9 +96,11 @@ void game_draw(struct game *game) {
 
     verify(map_data != NULL, "data for map '%s' not found", map_name);
     screen_draw_window(game->screen, map_data);
+    lua_pop(game->env, 1);
+
+    screen_draw_logs(game->screen, game->env);
 
     // Draw the game entities
-    lua_pop(game->env, 1);
     lua_pushstring(game->env, "entities");
     lua_gettable(game->env, -2);
     verify(lua_istable(game->env, -1), "entity list is not a table");

--- a/src/ui/screen.c
+++ b/src/ui/screen.c
@@ -1,5 +1,6 @@
 #include "ui/draw.h"
 #include "ui/screen.h"
+#include "util.h"
 
 #define ARRAYLEN(arr) ((sizeof (arr)) / (sizeof (arr)[0]))
 
@@ -24,8 +25,6 @@ void screen_draw_object(const struct screen *screen, struct tb_cell object, size
 }
 
 void screen_draw_window(const struct screen *screen, const struct tb_cell *window) {
-    size_t i;
-
     // window box
     draw_rectangle(1, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
     tb_blit(2, 1, WINDOW_WIDTH, WINDOW_HEIGHT, &window[0]);
@@ -36,10 +35,21 @@ void screen_draw_window(const struct screen *screen, const struct tb_cell *windo
 
     // chat box
     draw_horizontal_line(0, WINDOW_HEIGHT + 2, tb_width());
+}
 
-    struct log_node *node = screen->log;
-    for (i = 0; node != NULL && i < LOG_LINE_COUNT; ++i) {
-        draw_string_styled(0, WINDOW_HEIGHT + 3 + (LOG_LINE_COUNT - i), node->content, node->fg, node->bg);
-        node = node->next;
+void screen_draw_logs(const struct screen *screen, lua_State *env) {
+    verify(lua_istable(env, -1), "game object not on top of stack");
+
+    lua_pushstring(env, "log_entries");
+    lua_gettable(env, -2);
+    verify(lua_istable(env, -1), "log_entries is not a table");
+
+    lua_pushnil(env);
+    for (size_t i = 0; i < LOG_LINE_COUNT && lua_next(env, -2) != 0; i++) {
+        verify(lua_isstring(env, -1), "log entry is not a string");
+        draw_string(0, WINDOW_HEIGHT + 3 + (LOG_LINE_COUNT - i), lua_tostring(env, -1));
+        lua_pop(env, 1);
     }
+
+    lua_pop(env, 1);
 }

--- a/src/ui/screen.c
+++ b/src/ui/screen.c
@@ -16,8 +16,6 @@ void screen_init(struct screen *screen) {
     for (i = 0; i < ARRAYLEN(screen->info); ++i) {
         screen->info[i] = EMPTY_CELL;
     }
-
-    screen->log = NULL;
 }
 
 void screen_draw_object(const struct screen *screen, struct tb_cell object, size_t x, size_t y) {


### PR DESCRIPTION
In consequence of moving logging to Lua we lose the ability to log from C (as well as set log styles).
20e5a9a introduces unexpected behavior but it seems to be caused by the Lua code.

Closes #6.  