### PR TITLE
Wide maps

### DIFF
--- a/editor/src/compile.js
+++ b/editor/src/compile.js
@@ -24,10 +24,13 @@ const compile = (grid, name) => {
 
     return `
 #include <termbox.h>
+#include "map/map.h"
 
-struct tb_cell map_${mapName}[] = {
+static struct tb_cell map_data[] = {
     ${cells.join(',\n    ')}
 };
+
+struct map map_${mapName} = { map_data, ${MAP_WIDTH}, ${MAP_HEIGHT} };
 `
 }
 

--- a/include/map/map.h
+++ b/include/map/map.h
@@ -3,13 +3,19 @@
 
 #include <termbox.h>
 
+struct map {
+    const struct tb_cell *data;
+    const unsigned width;
+    const unsigned height;
+};
+
 /*
  * Retrieve a map by its name.
  * @param name The name of the map.
- * @return The map data, or NULL if no map can be found.
+ * @return The map struct, or NULL if no map can be found.
  */
-struct tb_cell *map_by_name(const char *name);
+struct map *map_by_name(const char *name);
 
-extern struct tb_cell map_river_asymmetric[];
+extern struct map map_river_asymmetric;
 
 #endif

--- a/include/ui/screen.h
+++ b/include/ui/screen.h
@@ -16,9 +16,14 @@
 
 /*
  * Draw the game window.
+ */
+void screen_draw_window();
+
+/*
+ * Draw the game map.
  * @param map The map structure to render in the window.
  */
-void screen_draw_window(const struct map *map);
+void screen_draw_map(const struct map *map);
 
 /*
  * Draw a game object in the window space.

--- a/include/ui/screen.h
+++ b/include/ui/screen.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <termbox.h>
 #include <lua.h>
+#include "map/map.h"
 
 #define LOG_LINE_COUNT 3
 
@@ -15,10 +16,9 @@
 
 /*
  * Draw the game window.
- * @param window An array of cells to render in the window. The array must
- *               have a length of WINDOW_WIDTH * WINDOW_HEIGHT.
+ * @param map The map structure to render in the window.
  */
-void screen_draw_window(const struct tb_cell *window);
+void screen_draw_window(const struct map *map);
 
 /*
  * Draw a game object in the window space.

--- a/src/game.c
+++ b/src/game.c
@@ -67,6 +67,7 @@ void game_dump_stack(struct game *game) {
 
 void game_draw(struct game *game) {
     tb_clear();
+    screen_draw_window();
 
     verify0(lua_istable(game->env, -1), "game object not on top of stack");
 
@@ -79,7 +80,7 @@ void game_draw(struct game *game) {
     const struct map *map = map_by_name(map_name);
 
     verify(map != NULL, "data for map '%s' not found", map_name);
-    screen_draw_window(map);
+    screen_draw_map(map);
     lua_pop(game->env, 1);
 
     screen_draw_logs(game->env);

--- a/src/game.c
+++ b/src/game.c
@@ -114,7 +114,7 @@ void game_draw(struct game *game) {
 
         const char *sprite = lua_tostring(game->env, -1);
         struct tb_cell object = { *sprite, TB_BLACK, TB_DEFAULT };
-        object.bg = map->data[map->height * y + x].bg;
+        object.bg = map->data[map->width * y + x].bg;
 
         lua_pop(game->env, 3);
         screen_draw_object(object, x, y);

--- a/src/game.c
+++ b/src/game.c
@@ -76,10 +76,10 @@ void game_draw(struct game *game) {
     verify0(lua_isstring(game->env, -1), "map name not a string");
 
     const char *map_name = lua_tostring(game->env, -1);
-    const struct tb_cell *map_data = map_by_name(map_name);
+    const struct map *map = map_by_name(map_name);
 
-    verify(map_data != NULL, "data for map '%s' not found", map_name);
-    screen_draw_window(map_data);
+    verify(map != NULL, "data for map '%s' not found", map_name);
+    screen_draw_window(map);
     lua_pop(game->env, 1);
 
     screen_draw_logs(game->env);
@@ -113,7 +113,7 @@ void game_draw(struct game *game) {
 
         const char *sprite = lua_tostring(game->env, -1);
         struct tb_cell object = { *sprite, TB_BLACK, TB_DEFAULT };
-        object.bg = map_data[WINDOW_WIDTH * y + x].bg;
+        object.bg = map->data[map->height * y + x].bg;
 
         lua_pop(game->env, 3);
         screen_draw_object(object, x, y);

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3,14 +3,14 @@
 
 struct map_entry {
     const char *name;
-    struct tb_cell *data;
+    struct map *map;
 };
 
 struct map_entry map_entries[] = {
-    { "river_asymmetric", &map_river_asymmetric[0] }
+    { "river_asymmetric", &map_river_asymmetric }
 };
 
-struct tb_cell *map_by_name(const char *name) {
+struct map *map_by_name(const char *name) {
     size_t i = 0;
 
     while (i < sizeof map_entries / sizeof map_entries[0]) {
@@ -18,7 +18,7 @@ struct tb_cell *map_by_name(const char *name) {
         const size_t name_len = strlen(entry_name);
 
         if (strncmp(entry_name, name, name_len) == 0) {
-            return map_entries[i].data;
+            return map_entries[i].map;
         }
 
         ++i;

--- a/src/map/map_river_asymmetric.c
+++ b/src/map/map_river_asymmetric.c
@@ -1,6 +1,7 @@
 #include <termbox.h>
+#include "map/map.h"
 
-struct tb_cell map_river_asymmetric[] = {
+static struct tb_cell map_data[] = {
     { ' ', TB_WHITE, TB_GREEN },
     { ' ', TB_WHITE, TB_GREEN },
     { ',', TB_WHITE, TB_GREEN },
@@ -758,3 +759,5 @@ struct tb_cell map_river_asymmetric[] = {
     { ' ', TB_WHITE, TB_GREEN },
     { ' ', TB_WHITE, TB_GREEN }
 };
+
+struct map map_river_asymmetric = { map_data, 54, 14 };

--- a/src/ui/screen.c
+++ b/src/ui/screen.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "ui/draw.h"
 #include "ui/screen.h"
 #include "util.h"
@@ -6,16 +7,28 @@ void screen_draw_object(struct tb_cell object, size_t x, size_t y) {
     tb_put_cell(x + 2, y + 1, &object);
 }
 
-void screen_draw_window(const struct map *map) {
+void screen_draw_window() {
     // window box
     draw_rectangle(1, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
-    tb_blit(2, 1, WINDOW_WIDTH, WINDOW_HEIGHT, map->data);
 
     // info box
     draw_vertical_line(WINDOW_WIDTH + 4, 0, WINDOW_HEIGHT + 2);
 
     // chat box
     draw_horizontal_line(0, WINDOW_HEIGHT + 2, tb_width());
+}
+
+void screen_draw_map(const struct map *map) {
+    struct tb_cell *cell_buffer = tb_cell_buffer();
+
+    size_t width = map->width > WINDOW_WIDTH ? WINDOW_WIDTH : map->width;
+    size_t height = map->height > WINDOW_HEIGHT ? WINDOW_HEIGHT : map->height;
+
+    for (size_t row = 0; row < height; row++) {
+        struct tb_cell *dest = cell_buffer + (row + 1) * tb_width() + 2;
+        const struct tb_cell *source = map->data + row * map->width;
+        memcpy(dest, source, width * sizeof(struct tb_cell));
+    }
 }
 
 void screen_draw_logs(lua_State *env) {

--- a/src/ui/screen.c
+++ b/src/ui/screen.c
@@ -6,10 +6,10 @@ void screen_draw_object(struct tb_cell object, size_t x, size_t y) {
     tb_put_cell(x + 2, y + 1, &object);
 }
 
-void screen_draw_window(const struct tb_cell *window) {
+void screen_draw_window(const struct map *map) {
     // window box
     draw_rectangle(1, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
-    tb_blit(2, 1, WINDOW_WIDTH, WINDOW_HEIGHT, &window[0]);
+    tb_blit(2, 1, WINDOW_WIDTH, WINDOW_HEIGHT, map->data);
 
     // info box
     draw_vertical_line(WINDOW_WIDTH + 4, 0, WINDOW_HEIGHT + 2);


### PR DESCRIPTION
I've made it so that maps can have arbitrary sizes which partially addresses #8. All data is still being kept inside a static array, however, I'm not sure if there is any benefit to keeping it that way. The drawing logic is no longer using `tb_blit` (which is deprecated) to allow drawing maps that are bigger than the window.

I haven't implemented the camera because there's currently no way to handle input. Smaller maps work well and bigger maps should also be displayed (their top left portion).

I have also updated the editor's compiler to generate valid code but it still uses constant dimensions (as there isn't really a way to use custom sized maps yet).