### PR TITLE
Print table contents in stack dumps

### DIFF
--- a/script/inspect.lua
+++ b/script/inspect.lua
@@ -1,0 +1,65 @@
+local escaping_rules = {
+  { '\\', '\\\\' },
+  { '"', '\\"' },
+  { '\n', '\\n' },
+  { '\t', '\\t' },
+  { '\a', '\\a' },
+  { '\b', '\\b' },
+  { '\f', '\\f' },
+  { '\v', '\\v' },
+}
+
+local function escape (s)
+  for _,rule in ipairs(escaping_rules) do
+    s = s:gsub(rule[1], rule[2])
+  end
+
+  return s
+end
+
+local function inspect_table (t, level, indent)
+  level = level or 0
+  indent = indent or '  '
+
+  local r = '{\n'
+  for k,v in pairs(t) do
+    local key
+    if type(k) == 'string' and k == escape(k) then
+      key = k
+    elseif type(k) == 'table' then
+      key = string.format('[%s]', inspect_table(k, level + 1, indent))
+    else
+      key = string.format('[%s]', inspect(k))
+    end
+
+    local value
+    if type(v) == 'table' then
+      value = inspect_table(v, level + 1)
+    else
+      value = inspect(v)
+    end
+
+    r = r .. indent:rep(level + 1) ..  string.format('%s = %s,\n', key, value)
+  end
+
+  r = r .. string.rep(indent, level) .. '}'
+  return r
+end
+
+local function inspect (value, level, indent)
+  level = level or 0
+  indent = indent or '  '
+
+  local repr
+  if type(value) == 'string' then
+    repr = string.format('"%s"', escape(value))
+  elseif type(value) == 'table' then
+    repr = inspect_table(value, level, indent)
+  else
+    repr = value
+  end
+
+  return string.rep(indent, level) .. repr
+end
+
+return inspect

--- a/script/prologue.lua
+++ b/script/prologue.lua
@@ -1,4 +1,5 @@
 dbg = require('script/debugger') -- the debugger
+inspect = require('script/inspect')
 local Entity = require('script/entity')
 
 Player = Entity:new({

--- a/src/lua_util.c
+++ b/src/lua_util.c
@@ -28,33 +28,17 @@ void lua_at(lua_State *state, int index, struct lua_value *value) {
 }
 
 void lua_dump_stack(lua_State *state) {
-    struct lua_value value;
-    int i = lua_gettop(state);
-
     log_fmt(LOGLEVEL_DEBUG, "=== stack");
-    while (i > 0) {
-        lua_at(state, i, &value);
 
-        switch (value.ty) {
-            case LUA_TSTRING:
-                log_fmt(LOGLEVEL_DEBUG, "%d: \'%s\'", i, value.str);
-                break;
-
-            case LUA_TBOOLEAN:
-                log_fmt(LOGLEVEL_DEBUG, "%d: %s", i, value.boolean ? "true" : "false");
-                break;
-
-            case LUA_TNUMBER:
-                log_fmt(LOGLEVEL_DEBUG, "%d: %g", i, value.number);
-                break;
-
-            default:
-                log_fmt(LOGLEVEL_DEBUG, "%d: %s", i, value.tyname);
-                break;
-        }
-
-        --i;
+    for (int i = lua_gettop(state); i > 0; i--) {
+        lua_getglobal(state, "inspect");
+        lua_pushvalue(state, i);
+        int result = lua_pcall(state, 1, 1, 0);
+        verify(result == 0, "couldn't call inspect: %s", lua_tostring(state, -1));
+        log_fmt(LOGLEVEL_DEBUG, "%d: %s", i, lua_tostring(state, -1));
+        lua_pop(state, 1);
     }
+
     log_fmt(LOGLEVEL_DEBUG, "===");
 }
 


### PR DESCRIPTION
I've changed the stack dumping routine to print detailed information about stack values. Most importantly the inspection algorithm also renders table contents and escapes some characters in strings. The output should almost always be valid Lua code. Even in the rare cases when that's not true the output should still remain readable.

Example output:
```
2018-09-04 10:10:26: DEBUG: 1: {
  player_description = {
    y = 12,
    id = 4,
    x = 21,
  },
  description = "the swans are in trouble and you must help them die",
  map = "river_asymmetric",
  entity_descriptions = {
    [1] = {
      y = 3,
      id = 1,
      x = 7,
    },
    [2] = {
      y = 2,
      id = 2,
      x = 34,
    },
    [3] = {
      y = 3,
      id = 3,
      x = 20,
    },
  },
  title = "siege of the swans",
}
```

The `inspect` routine is implemented in Lua and requires `prologue.lua` to be successfully loaded. If this ever becomes an issue the routine can be loaded directly from C. 